### PR TITLE
feat/pass

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -152,6 +152,21 @@ backup:
     days: 90
     max_backups_per_secret: 10
 
+  # Master key backup configuration
+  key_backup:
+    # How to provide passphrase for encrypted backups
+    # Options:
+    #   "interactive"           - Prompt each time (most secure, requires TTY)
+    #   "file:/path/to/file"    - Read from file (convenient for automation)
+    #   "env:VARIABLE_NAME"     - Read from environment variable (good for CI/CD)
+    #
+    # If not set, will auto-detect from standard locations:
+    #   - /run/secrets/backup_passphrase (Docker secret)
+    #   - ~/.config/secret-rotator/.backup-passphrase (PyPI user config)
+    #   - ~/.local/share/secret-rotator/.backup-passphrase (PyPI user data)
+    #   - /app/data/.backup-passphrase (Docker data volume)
+    passphrase_source: "interactive"
+
   # Master key backups stored in data volume (not read-only config)
   key_backups_path: "data/key_backups/"
 

--- a/src/secret_rotator/setup_wizard.py
+++ b/src/secret_rotator/setup_wizard.py
@@ -8,6 +8,7 @@ import sys
 import yaml
 import shutil
 from pathlib import Path
+from secret_rotator.utils.passphrase_manager import PassphraseManager
 
 
 def get_config_dir():
@@ -233,6 +234,75 @@ def print_summary(config_dir, data_dir, log_dir, config_file):
     print("   http://localhost:8080")
 
     print("\n" + "=" * 70)
+
+
+def setup_backup_passphrase(config_dir, data_dir):
+    """Configure backup passphrase during initial setup"""
+    print("\n" + "=" * 70)
+    print("BACKUP PASSPHRASE CONFIGURATION")
+    print("=" * 70)
+    print("\nFor encrypting master key backups, you need a passphrase.")
+    print("How would you like to provide this passphrase?\n")
+    
+    print("1. Interactive (ask each time) - Most secure")
+    print("2. Store in secure file - Convenient for automation")
+    print("3. Environment variable - Good for CI/CD")
+    print("4. I'll configure this later")
+    
+    choice = input("\nSelect option [1]: ").strip() or "1"
+    
+    config_value = "interactive"  # default
+    
+    if choice == "1":
+        print("\n✓ Passphrase will be requested interactively when needed")
+        config_value = "interactive"
+    
+    elif choice == "2":
+        print("\nCreating secure passphrase file...")
+        
+        # Determine best location
+        if os.path.exists('/app/data'):  # Docker environment
+            passphrase_file = Path('/app/data/.backup-passphrase')
+            display_path = '/app/data/.backup-passphrase'
+        else:  # PyPI installation
+            passphrase_file = config_dir / '.backup-passphrase'
+            display_path = str(passphrase_file)
+        
+        # Use PassphraseManager to create file
+        pm = PassphraseManager()
+        success = pm.create_passphrase_file(
+            str(passphrase_file),
+            passphrase=None,  # Will prompt
+            interactive=True
+        )
+        
+        if success:
+            config_value = f"file:{passphrase_file}"
+            print(f"\n✓ Passphrase file created: {display_path}")
+            print("  This file will be used automatically for encrypted backups")
+        else:
+            print("\n⚠️  Failed to create passphrase file, using interactive mode")
+            config_value = "interactive"
+    
+    elif choice == "3":
+        env_var = input("Environment variable name [BACKUP_PASSPHRASE]: ").strip()
+        env_var = env_var or "BACKUP_PASSPHRASE"
+        
+        print(f"\n✓ Will use environment variable: {env_var}")
+        print(f"\nAdd this to your environment:")
+        print(f"  export {env_var}='your-secure-passphrase-here'")
+        config_value = f"env:{env_var}"
+    
+    elif choice == "4":
+        print("\n✓ Backup passphrase not configured")
+        print("  You can configure this later in config.yaml")
+        config_value = "interactive"
+    
+    else:
+        print("\n⚠️  Invalid choice, using interactive mode")
+        config_value = "interactive"
+    
+    return config_value
 
 
 def main():

--- a/src/secret_rotator/setup_wizard.py
+++ b/src/secret_rotator/setup_wizard.py
@@ -329,16 +329,33 @@ def main():
         sys.exit(0)
 
     try:
-        # Create directories
         create_directories(config_dir, data_dir, log_dir)
 
-        # Create configuration
         config_file = create_config(config_dir, data_dir, log_dir)
 
-        # Setup encryption
+        # Setup backup passphrase configuration
+        print("\n" + "=" * 70)
+        print("STEP 4: BACKUP CONFIGURATION")
+        print("=" * 70)
+        backup_passphrase_config = setup_backup_passphrase(config_dir, data_dir)
+        
+        with open(config_file, 'r') as f:
+            config = yaml.safe_load(f)
+        
+        if 'backup' not in config:
+            config['backup'] = {}
+        
+        config['backup']['key_backup'] = {
+            'passphrase_source': backup_passphrase_config
+        }
+        
+        with open(config_file, 'w') as f:
+            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        
+        print(f"✓ Configuration updated: {config_file}")
+
         setup_encryption(config_dir)
 
-        # Print summary
         print_summary(config_dir, data_dir, log_dir, config_file)
 
     except KeyboardInterrupt:

--- a/src/secret_rotator/tools/manage_key_backups.py
+++ b/src/secret_rotator/tools/manage_key_backups.py
@@ -336,8 +336,28 @@ def restore_backup(args):
 
     # Check if encrypted backup
     if args.backup_file.endswith(".enc"):
-        passphrase = getpass.getpass("\nEnter passphrase: ")
-
+        from secret_rotator.config.settings import settings
+        passphrase_mgr = PassphraseManager(config_manager=settings)
+        
+        passphrase, source = passphrase_mgr.get_passphrase(
+            cli_file=getattr(args, 'passphrase_file', None),
+            allow_interactive=True,
+            purpose="backup restoration"
+        )
+        
+        if source == "interactive_required":
+            try:
+                passphrase = getpass.getpass("\nEnter passphrase: ")
+            except KeyboardInterrupt:
+                print("\n\nCancelled by user")
+                sys.exit(0)
+        elif passphrase is None:
+            if source == "non_interactive_no_source":
+                passphrase_mgr.print_help_message()
+            else:
+                print(f"ERROR: {source}", file=sys.stderr)
+            sys.exit(1)
+            
         try:
             success = manager.restore_from_encrypted_backup(args.backup_file, passphrase)
 

--- a/src/secret_rotator/tools/manage_key_backups.py
+++ b/src/secret_rotator/tools/manage_key_backups.py
@@ -11,12 +11,14 @@ Usage:
     secret-rotator-backup restore-split share1.share share2.share share3.share
     secret-rotator-backup export-instructions --output KEY_BACKUP_INSTRUCTIONS.txt
 """
+import os
 import sys
 import argparse
 import getpass
 from pathlib import Path
 
 from secret_rotator.key_backup_manager import MasterKeyBackupManager
+from secret_rotator.utils.passphrase_manager import PassphraseManager
 
 
 def create_encrypted_backup(args):
@@ -26,36 +28,68 @@ def create_encrypted_backup(args):
     print("\n" + "=" * 70)
     print("CREATE ENCRYPTED MASTER KEY BACKUP")
     print("=" * 70)
-    print("\nThis will create an encrypted backup of your master encryption key.")
-    print("You will be prompted to enter a strong passphrase.")
-    print("\nIMPORTANT:")
-    print("  - Use a passphrase with 20+ characters")
-    print("  - Include uppercase, lowercase, numbers, and symbols")
-    print("  - Store the passphrase in a secure password manager")
-    print("  - Without this passphrase, the backup CANNOT be recovered")
-    print("\nBEST PRACTICE:")
-    print("  - After creating the backup, copy the .enc file to external storage")
-    print("  - Examples: AWS S3, Azure Blob, Google Drive, encrypted USB drive")
-    print("  - The encrypted file is safe to store in cloud storage")
-    print()
-
-    # Get passphrase
-    while True:
-        passphrase = getpass.getpass("Enter passphrase: ")
-        passphrase_confirm = getpass.getpass("Confirm passphrase: ")
-
-        if passphrase != passphrase_confirm:
-            print("ERROR: Passphrases do not match. Try again.\n")
-            continue
-
-        if len(passphrase) < 20:
-            print("WARNING: Passphrase should be at least 20 characters.")
-            response = input("Continue anyway? (yes/no): ")
-            if response.lower() != "yes":
-                continue
-
-        break
-
+    
+    # Initialize passphrase manager with config
+    from secret_rotator.config.settings import settings
+    passphrase_mgr = PassphraseManager(config_manager=settings)
+    
+    # Get passphrase using unified system
+    passphrase, source = passphrase_mgr.get_passphrase(
+        cli_file=getattr(args, 'passphrase_file', None),
+        allow_interactive=True,
+        purpose="master key backup encryption"
+    )
+    
+    # Handle different source results
+    if source == "interactive_required":
+        # Show helpful information before prompting
+        print("\nThis will create an encrypted backup of your master encryption key.")
+        print("You will be prompted to enter a strong passphrase.")
+        print("\nIMPORTANT:")
+        print("  - Use a passphrase with 20+ characters")
+        print("  - Include uppercase, lowercase, numbers, and symbols")
+        print("  - Store the passphrase in a secure password manager")
+        print("  - Without this passphrase, the backup CANNOT be recovered")
+        print("\nTo avoid entering passphrase each time, you can create a passphrase file:")
+        
+        # Platform-specific hint
+        if os.path.exists('/.dockerenv') or os.path.exists('/run/secrets'):
+            print("  docker exec secret-rotator bash -c 'echo \"passphrase\" > /app/data/.backup-passphrase'")
+            print("  docker exec secret-rotator chmod 600 /app/data/.backup-passphrase")
+        else:
+            print("  echo 'your-passphrase' > ~/.config/secret-rotator/.backup-passphrase")
+            print("  chmod 600 ~/.config/secret-rotator/.backup-passphrase")
+        
+        try:
+            passphrase = passphrase_mgr.prompt_interactive(
+                purpose="master key backup encryption",
+                min_length=20,
+                require_confirmation=True
+            )
+        except KeyboardInterrupt:
+            print("\n\nCancelled by user")
+            sys.exit(0)
+    
+    elif source == "non_interactive_no_source":
+        # No source found and we're non-interactive
+        passphrase_mgr.print_help_message()
+        sys.exit(1)
+    
+    elif passphrase is None:
+        # Some other error
+        print(f"ERROR: {source}", file=sys.stderr)
+        sys.exit(1)
+    
+    else:
+        # Got passphrase from non-interactive source
+        print(f"✓ Using passphrase from: {source}", file=sys.stderr)
+    
+    # Validate passphrase
+    if not passphrase or len(passphrase) < 8:
+        print("ERROR: Passphrase must be at least 8 characters", file=sys.stderr)
+        sys.exit(1)
+    
+    # Create the backup
     try:
         backup_file = manager.create_encrypted_key_backup(
             passphrase=passphrase, backup_name=args.name
@@ -66,8 +100,13 @@ def create_encrypted_backup(args):
         print("\nNext steps:")
         print("  1. Store the passphrase in a secure password manager")
         print("  2. Copy the backup file to external storage:")
-        print(f"     - For Docker: docker cp secret-rotator:{backup_file} ./external-backup/")
-        print(f"     - For local: cp {backup_file} /path/to/external/storage/")
+        
+        if os.path.exists('/.dockerenv') or os.path.exists('/run/secrets'):
+            print(f"     docker cp secret-rotator:{backup_file} ./external-backup/")
+            print("     # Then upload to S3, Azure, or other secure storage")
+        else:
+            print(f"     cp {backup_file} /path/to/external/storage/")
+        
         print("  3. Test restoration in non-production environment:")
         print(f"     secret-rotator-backup verify {backup_file}")
         print("\n  Recommended external storage options:")
@@ -79,7 +118,6 @@ def create_encrypted_backup(args):
     except Exception as e:
         print(f"\n✗ ERROR: Failed to create backup: {e}")
         sys.exit(1)
-
 
 def create_split_backup(args):
     """Create a split key backup using Shamir's Secret Sharing"""

--- a/src/secret_rotator/tools/manage_key_backups.py
+++ b/src/secret_rotator/tools/manage_key_backups.py
@@ -357,7 +357,7 @@ def restore_backup(args):
             else:
                 print(f"ERROR: {source}", file=sys.stderr)
             sys.exit(1)
-            
+
         try:
             success = manager.restore_from_encrypted_backup(args.backup_file, passphrase)
 
@@ -464,11 +464,10 @@ Examples:
   
   # Restore from split key shares
   secret-rotator-backup restore-split share1.share share2.share share3.share
-
-Architecture Note:
-  Master key: data/.master.key (read-only)
-  Backups:    data/key_backups/ (writable)
-  This separation maintains security isolation.
+  
+  # Export backup and recovery instructions
+  secret-rotator-backup export-instructions --output KEY_BACKUP_INSTRUCTIONS.txt
+  
         """,
     )
 
@@ -492,6 +491,11 @@ Architecture Note:
     )
     parser_encrypted.add_argument("--name", help="Optional backup name")
 
+    parser_encrypted.add_argument(
+        "--passphrase-file",
+        help="File containing passphrase (overrides other sources)"
+    )
+
     # Create split key backup
     parser_split = subparsers.add_parser(
         "create-split", help="Create split key backup (Shamir Secret Sharing)"
@@ -513,10 +517,18 @@ Architecture Note:
     # Verify backup
     parser_verify = subparsers.add_parser("verify", help="Verify a backup")
     parser_verify.add_argument("backup_file", help="Path to backup file")
+    parser_verify.add_argument(
+        "--passphrase-file",
+        help="File containing passphrase (for encrypted backups)"
+    )
 
     # Restore from backup
     parser_restore = subparsers.add_parser("restore", help="Restore from encrypted backup")
     parser_restore.add_argument("backup_file", help="Path to backup file")
+    parser_restore.add_argument(
+        "--passphrase-file",
+        help="File containing passphrase"
+    )
 
     # Restore from split
     parser_restore_split = subparsers.add_parser(

--- a/src/secret_rotator/tools/manage_key_backups.py
+++ b/src/secret_rotator/tools/manage_key_backups.py
@@ -262,9 +262,29 @@ def verify_backup(args):
     print("=" * 70)
     print(f"\nVerifying: {args.backup_file}")
 
-    # Check if encrypted backup
     if args.backup_file.endswith(".enc"):
-        passphrase = getpass.getpass("\nEnter passphrase: ")
+
+        from secret_rotator.config.settings import settings
+        passphrase_mgr = PassphraseManager(config_manager=settings)
+        
+        passphrase, source = passphrase_mgr.get_passphrase(
+            cli_file=getattr(args, 'passphrase_file', None),
+            allow_interactive=True,
+            purpose="backup verification"
+        )
+        
+        if source == "interactive_required":
+            try:
+                passphrase = getpass.getpass("\nEnter passphrase: ")
+            except KeyboardInterrupt:
+                print("\n\nCancelled by user")
+                sys.exit(0)
+        elif passphrase is None:
+            if source == "non_interactive_no_source":
+                passphrase_mgr.print_help_message()
+            else:
+                print(f"ERROR: {source}", file=sys.stderr)
+            sys.exit(1)
 
         try:
             success = manager.verify_backup(args.backup_file, passphrase)

--- a/src/secret_rotator/utils/passphrase_manager.py
+++ b/src/secret_rotator/utils/passphrase_manager.py
@@ -92,6 +92,10 @@ class PassphraseManager:
             # If we're non-interactive and nothing worked, fail with helpful message
             return None, "non_interactive_no_source"
         
+        # Priority 6: Interactive prompt
+        if allow_interactive:
+            return None, "interactive_required"
+        
         return None, "no_source_available"
     
     def _read_from_file(self, file_path: str) -> Optional[str]:

--- a/src/secret_rotator/utils/passphrase_manager.py
+++ b/src/secret_rotator/utils/passphrase_manager.py
@@ -113,3 +113,47 @@ class PassphraseManager:
     def _get_from_config(self) -> Tuple[Optional[str], str]:
         """Get passphrase based on config file settings"""
         return None, ""
+    
+    def prompt_interactive(self, 
+                          purpose: str = "backup encryption",
+                          min_length: int = 20,
+                          require_confirmation: bool = True) -> str:
+        """
+        Interactively prompt for passphrase with validation.
+        
+        Args:
+            purpose: What the passphrase is for
+            min_length: Minimum required length
+            require_confirmation: Whether to ask for confirmation
+        
+        Returns:
+            The entered passphrase
+        
+        Raises:
+            KeyboardInterrupt: If user cancels
+        """
+        print(f"\nEnter passphrase for {purpose}")
+        print(f"Minimum length: {min_length} characters")
+        print()
+        
+        while True:
+            passphrase = getpass.getpass("Enter passphrase: ")
+            
+            if not passphrase:
+                print("ERROR: Passphrase cannot be empty\n")
+                continue
+            
+            if len(passphrase) < min_length:
+                print(f"⚠️  WARNING: Passphrase is only {len(passphrase)} characters "
+                      f"(recommended: {min_length}+)")
+                response = input("Continue anyway? (yes/no): ")
+                if response.lower() != "yes":
+                    continue
+            
+            if require_confirmation:
+                passphrase_confirm = getpass.getpass("Confirm passphrase: ")
+                if passphrase != passphrase_confirm:
+                    print("ERROR: Passphrases do not match. Try again.\n")
+                    continue
+            
+            return passphrase

--- a/src/secret_rotator/utils/passphrase_manager.py
+++ b/src/secret_rotator/utils/passphrase_manager.py
@@ -112,6 +112,25 @@ class PassphraseManager:
     
     def _get_from_config(self) -> Tuple[Optional[str], str]:
         """Get passphrase based on config file settings"""
+        source = self.config_manager.get('backup.key_backup.passphrase_source')
+        if not source:
+            return None, ""
+        
+        # Config specifies a file
+        if source.startswith('file:'):
+            file_path = source.replace('file:', '', 1)
+            file_path = os.path.expanduser(file_path)
+            passphrase = self._read_from_file(file_path)
+            if passphrase:
+                return passphrase, f"config file source: {file_path}"
+        
+        # Config specifies an environment variable
+        elif source.startswith('env:'):
+            env_var = source.replace('env:', '', 1)
+            passphrase = os.getenv(env_var)
+            if passphrase:
+                return passphrase, f"config env variable: {env_var}"
+        
         return None, ""
     
     def prompt_interactive(self, 

--- a/src/secret_rotator/utils/passphrase_manager.py
+++ b/src/secret_rotator/utils/passphrase_manager.py
@@ -80,6 +80,18 @@ class PassphraseManager:
         if env_passphrase:
             return env_passphrase, "BACKUP_PASSPHRASE environment variable"
         
+        # Priority 5: Stdin (for piping)
+        if not sys.stdin.isatty():
+            try:
+                passphrase = sys.stdin.readline().strip()
+                if passphrase:
+                    return passphrase, "stdin"
+            except Exception:
+                pass
+            
+            # If we're non-interactive and nothing worked, fail with helpful message
+            return None, "non_interactive_no_source"
+        
         return None, "no_source_available"
     
     def _read_from_file(self, file_path: str) -> Optional[str]:

--- a/src/secret_rotator/utils/passphrase_manager.py
+++ b/src/secret_rotator/utils/passphrase_manager.py
@@ -3,11 +3,21 @@ Universal passphrase management for PyPI and Docker deployments.
 Handles passphrase retrieval from multiple sources with intelligent fallbacks.
 """
 
+import os
+from pathlib import Path
 from typing import Optional, Tuple
 
 
 class PassphraseManager:
     """Unified passphrase handling for all installation types"""
+    
+    # Standard locations checked in order (works for both PyPI and Docker)
+    STANDARD_LOCATIONS = [
+        '/run/secrets/backup_passphrase',  # Docker secret (Swarm/Compose)
+        '~/.local/share/secret-rotator/.backup-passphrase',  # XDG data dir (PyPI)
+        '~/.config/secret-rotator/.backup-passphrase',  # XDG config dir (PyPI)
+        '/app/data/.backup-passphrase',  # Docker data volume
+    ]
     
     def __init__(self, config_manager=None):
         """
@@ -41,4 +51,42 @@ class PassphraseManager:
         Returns:
             Tuple of (passphrase, source_description) or (None, reason)
         """
+        
+        # Priority 1: CLI argument (explicit override)
+        if cli_file:
+            passphrase = self._read_from_file(cli_file)
+            if passphrase:
+                return passphrase, f"CLI argument: {cli_file}"
+            else:
+                return None, f"CLI file not found or empty: {cli_file}"
+        
+        # Priority 2: Config file setting
+        if self.config_manager:
+            passphrase, source = self._get_from_config()
+            if passphrase:
+                return passphrase, source
+        
+        # Priority 3: Standard locations (convention over configuration)
+        for location in self.STANDARD_LOCATIONS:
+            expanded_path = os.path.expanduser(location)
+            passphrase = self._read_from_file(expanded_path)
+            if passphrase:
+                return passphrase, f"standard location: {location}"
+        
         return None, "no_source_available"
+    
+    def _read_from_file(self, file_path: str) -> Optional[str]:
+        """Safely read passphrase from file"""
+        try:
+            path = Path(file_path)
+            if path.exists() and path.is_file():
+                with open(path, 'r') as f:
+                    content = f.read().strip()
+                    return content if content else None
+        except (IOError, PermissionError, OSError):
+            pass
+        return None
+    
+    def _get_from_config(self) -> Tuple[Optional[str], str]:
+        """Get passphrase based on config file settings"""
+        return None, ""

--- a/src/secret_rotator/utils/passphrase_manager.py
+++ b/src/secret_rotator/utils/passphrase_manager.py
@@ -4,6 +4,8 @@ Handles passphrase retrieval from multiple sources with intelligent fallbacks.
 """
 
 import os
+import sys
+import getpass
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -72,6 +74,11 @@ class PassphraseManager:
             passphrase = self._read_from_file(expanded_path)
             if passphrase:
                 return passphrase, f"standard location: {location}"
+        
+        # Priority 4: Environment variable
+        env_passphrase = os.getenv('BACKUP_PASSPHRASE')
+        if env_passphrase:
+            return env_passphrase, "BACKUP_PASSPHRASE environment variable"
         
         return None, "no_source_available"
     

--- a/src/secret_rotator/utils/passphrase_manager.py
+++ b/src/secret_rotator/utils/passphrase_manager.py
@@ -176,3 +176,57 @@ class PassphraseManager:
                     continue
             
             return passphrase
+    
+    def print_help_message(self, is_docker: Optional[bool] = None):
+        """
+        Print helpful error message with platform-specific instructions.
+        
+        Args:
+            is_docker: True for Docker, False for PyPI, None for auto-detect
+        """
+        if is_docker is None:
+            # Auto-detect: check if we're in Docker
+            is_docker = os.path.exists('/.dockerenv') or os.path.exists('/run/secrets')
+        
+        print("\n" + "=" * 70, file=sys.stderr)
+        print("ERROR: No passphrase available (non-interactive mode)", file=sys.stderr)
+        print("=" * 70, file=sys.stderr)
+        print("\nProvide passphrase using one of these methods:\n", file=sys.stderr)
+        
+        print("1. Create passphrase file (RECOMMENDED):", file=sys.stderr)
+        if is_docker:
+            print("   # On host machine:", file=sys.stderr)
+            print("   mkdir -p secrets", file=sys.stderr)
+            print("   echo 'your-passphrase' > secrets/backup_passphrase.txt", file=sys.stderr)
+            print("   chmod 600 secrets/backup_passphrase.txt", file=sys.stderr)
+            print("   # Then configure docker-compose.yml to mount as secret", file=sys.stderr)
+            print("   # OR:", file=sys.stderr)
+            print("   docker exec secret-rotator bash -c \\", file=sys.stderr)
+            print("     'echo \"passphrase\" > /app/data/.backup-passphrase'", file=sys.stderr)
+            print("   docker exec secret-rotator chmod 600 /app/data/.backup-passphrase", file=sys.stderr)
+        else:
+            print("   mkdir -p ~/.config/secret-rotator", file=sys.stderr)
+            print("   echo 'your-passphrase' > ~/.config/secret-rotator/.backup-passphrase", file=sys.stderr)
+            print("   chmod 600 ~/.config/secret-rotator/.backup-passphrase", file=sys.stderr)
+        print()
+        
+        print("2. Use CLI argument:", file=sys.stderr)
+        print("   secret-rotator-backup create-encrypted --passphrase-file /path/to/file", file=sys.stderr)
+        print()
+        
+        print("3. Use environment variable:", file=sys.stderr)
+        print("   export BACKUP_PASSPHRASE='your-passphrase'", file=sys.stderr)
+        print("   secret-rotator-backup create-encrypted", file=sys.stderr)
+        print()
+        
+        print("4. Pipe from stdin:", file=sys.stderr)
+        print("   echo 'your-passphrase' | secret-rotator-backup create-encrypted", file=sys.stderr)
+        print()
+        
+        print("5. Interactive mode (requires TTY):", file=sys.stderr)
+        if is_docker:
+            print("   docker exec -it secret-rotator secret-rotator-backup create-encrypted", file=sys.stderr)
+        else:
+            print("   secret-rotator-backup create-encrypted", file=sys.stderr)
+        
+        print("=" * 70, file=sys.stderr)

--- a/src/secret_rotator/utils/passphrase_manager.py
+++ b/src/secret_rotator/utils/passphrase_manager.py
@@ -230,3 +230,50 @@ class PassphraseManager:
             print("   secret-rotator-backup create-encrypted", file=sys.stderr)
         
         print("=" * 70, file=sys.stderr)
+    
+    def create_passphrase_file(self, 
+                               file_path: str,
+                               passphrase: Optional[str] = None,
+                               interactive: bool = True) -> bool:
+        """
+        Create a passphrase file with proper permissions.
+        
+        Args:
+            file_path: Where to create the file
+            passphrase: Passphrase to write (if None, will prompt if interactive)
+            interactive: Whether to prompt if passphrase not provided
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        if not passphrase and interactive:
+            try:
+                passphrase = self.prompt_interactive(
+                    purpose="storage in file",
+                    require_confirmation=True
+                )
+            except KeyboardInterrupt:
+                print("\nCancelled by user")
+                return False
+        
+        if not passphrase:
+            return False
+        
+        try:
+            path = Path(file_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            
+            # Write passphrase
+            with open(path, 'w') as f:
+                f.write(passphrase)
+            
+            # Set restrictive permissions
+            os.chmod(path, 0o600)
+            
+            print(f"✓ Passphrase saved to: {file_path}")
+            print(f"  Permissions: 600 (owner read/write only)")
+            return True
+            
+        except (IOError, OSError) as e:
+            print(f"ERROR: Failed to create passphrase file: {e}", file=sys.stderr)
+            return False

--- a/src/secret_rotator/utils/passphrase_manager.py
+++ b/src/secret_rotator/utils/passphrase_manager.py
@@ -1,0 +1,44 @@
+"""
+Universal passphrase management for PyPI and Docker deployments.
+Handles passphrase retrieval from multiple sources with intelligent fallbacks.
+"""
+
+from typing import Optional, Tuple
+
+
+class PassphraseManager:
+    """Unified passphrase handling for all installation types"""
+    
+    def __init__(self, config_manager=None):
+        """
+        Initialize passphrase manager.
+        
+        Args:
+            config_manager: Optional settings object for config-based sources
+        """
+        self.config_manager = config_manager
+    
+    def get_passphrase(self, 
+                       cli_file: Optional[str] = None,
+                       allow_interactive: bool = True,
+                       purpose: str = "backup encryption") -> Tuple[Optional[str], str]:
+        """
+        Get passphrase from various sources with priority order.
+        
+        Priority:
+        1. CLI argument (--passphrase-file)
+        2. Config file setting
+        3. Standard file locations
+        4. Environment variable
+        5. Stdin (non-interactive)
+        6. Interactive prompt (if allowed)
+        
+        Args:
+            cli_file: Explicit passphrase file from CLI argument
+            allow_interactive: Whether to allow interactive prompts
+            purpose: Description of what the passphrase is for (for prompts)
+        
+        Returns:
+            Tuple of (passphrase, source_description) or (None, reason)
+        """
+        return None, "no_source_available"


### PR DESCRIPTION
adds a passphrase manager to handle passphrases in both interactive and non-interactive environments.
users can now handle passphrases through: 
- interactive mode
- env variables
- cli arguments
- docker secrets
- file-based 
- stdin piping

fixes #21 